### PR TITLE
Error Message on 500 error from backend while exporting. 

### DIFF
--- a/ide/static/js/content.js
+++ b/ide/static/js/content.js
@@ -231,9 +231,10 @@ class Content extends React.Component {
           }
           this.setState({ load: false });
         }.bind(this),
-        error() {
-          this.setState({ load: false });
-        }
+        error : function () {
+       	  this.setState({ load: false });
+	  this.addError("Error");
+        }.bind(this)
       });
     }
   }

--- a/ide/static/js/content.js
+++ b/ide/static/js/content.js
@@ -291,10 +291,10 @@ class Content extends React.Component {
         }
         this.setState({ load: false });
       }.bind(this),
-      error() {
-        // console.log('failure');
+      error : function () {
         this.setState({ load: false });
-      }
+        this.addError("Error");
+      }.bind(this)
     });
   }
   initialiseImportedNet(net,net_name) {

--- a/ide/static/js/content.js
+++ b/ide/static/js/content.js
@@ -232,8 +232,8 @@ class Content extends React.Component {
           this.setState({ load: false });
         }.bind(this),
         error : function () {
-       	  this.setState({ load: false });
-	  this.addError("Error");
+          this.setState({ load: false });
+          this.addError("Error");
         }.bind(this)
       });
     }


### PR DESCRIPTION
This code changes the behavior when the frontend gets a 500 error from the backend, it throws an error now, rather than just infinitely hanging on a loading screen.

I am getting a mixed tabs and spaces error though, what would be the easiest way to fix it? Are there automated tools to fix it?  