### PR TITLE
Host all documentation on readthedocs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,12 +6,16 @@
 Welcome to Fabrik's documentation!
 ==================================
 
+Fabrik is an online collaborative platform to build, visualize and train deep learning models via a simple drag-and-drop interface. It allows researchers to collaboratively develop and debug models using a web GUI that supports importing, editing and exporting networks written in widely popular frameworks like Caffe, Keras, and TensorFlow.
+
 Contents:
 
 .. toctree::
    :maxdepth: 2
 
-
+   setup
+   keras_json_usage
+   tested_models
 
 Indices and tables
 ==================

--- a/docs/source/keras_json_usage.md
+++ b/docs/source/keras_json_usage.md
@@ -1,0 +1,75 @@
+### Basics of Using the Exported Keras Model
+
+We want to export our model for Keras from Fabrik.
+
+1. First, select the 2nd button from the left in the Actions section of the sidebar.
+<img src="exportbutton.png">
+
+2. A drop-down list should appear. Select Keras.
+    * This should download a JSON file to your computer.
+<img src="exportdropdown.png">
+
+3. Rename the file to ```model.json```.
+
+4. Load the model from the JSON file using the following code:
+    ```
+    from keras.models import model_from_json
+
+    # Read and load the JSON file
+    json_file = open('<path_to_file>/model.json', 'r')
+    loaded_model_json = json_file.read()
+    json_file.close()
+
+    # Use Keras's built in model_from_json function to convert the JSON file to a model
+    loaded_model = model_from_json(loaded_model_json)
+
+    # Print a summary of the model to verify that the model loaded correctly
+    print (loaded_model.summary())
+    ```
+### Example<sup>[1](https://machinelearningmastery.com/save-load-keras-deep-learning-models/)</sup>
+1. [Export](http://fabrik.cloudcv.org/caffe/load?id=20171207035101pfjnz) this example Keras model (name it ```model.json```).
+
+2. [Download](http://archive.ics.uci.edu/ml/machine-learning-databases/pima-indians-diabetes/pima-indians-diabetes.data) this data set that we will use to train on (name it ```pima-indians-diabetes.csv```).
+
+3. Create a python file (name it ```kerasJSONLoader.py```) and insert the following code:
+   ```
+   from keras.models import model_from_json
+   import numpy
+   import os
+
+   # Fix random seed to allow similar accuracy measures at the end
+   numpy.random.seed(7)
+
+   # Load pima indians dataset
+   dataset = numpy.loadtxt('<path_to_file>/pima-indians-diabetes.csv', delimiter=',')
+
+   # Split the dataset into input (X) and output (Y) variables
+   X = dataset[:,0:8]
+   Y = dataset[:,8]
+
+   # Load the model from JSON file
+   json_file = open('<path_to_file>/model.json', 'r')
+   loaded_model_json = json_file.read()
+   json_file.close()
+   loaded_model = model_from_json(loaded_model_json)
+
+   # Configure model for training and testing with accuracy evaluation
+   loaded_model.compile(loss='binary_crossentropy', optimizer='adam', metrics=['accuracy'])
+
+   # Train the model
+   loaded_model.fit(X, Y, epochs=150, batch_size=10, verbose=0)
+
+   # Evaluate the model
+   scores = loaded_model.evaluate(X, Y, verbose=0)
+
+   # Print final accuracy
+   print("%s: %.2f%%" % (loaded_model.metrics_names[1], scores[1] * 100))
+   ```
+4. Then run the code in terminal.
+   ```
+   python <path_to_file>/kerasJSONLoader.py
+   ```
+You should be getting around 76-78% accuracy.
+
+This code trains and evaluates the loaded model on the dataset.
+

--- a/docs/source/setup.md
+++ b/docs/source/setup.md
@@ -1,0 +1,76 @@
+### How to setup
+1. First set up a virtualenv
+    ```
+    sudo apt-get install python-pip python-dev python-virtualenv 
+    virtualenv --system-site-packages ~/Fabrik
+    source ~/Fabrik/bin/activate
+    ```
+    
+2. Clone the repository
+    ```
+    git clone --recursive https://github.com/Cloud-CV/Fabrik.git
+    ```
+    
+3. If you have Caffe, Keras and Tensorflow already installed on your computer, skip this step
+    * For Linux users
+        ```
+        cd Fabrik/requirements
+        yes Y | sh caffe_tensorflow_keras_install.sh
+        ```
+        Open your ~/.bashrc file and append this line at the end
+        ```        
+        export PYTHONPATH=~/caffe/caffe/python:$PYTHONPATH
+        ```
+        Save, exit and then run
+        ```
+        source ~/.bash_profile
+        cd .. 
+        ```
+    * For Mac users
+        * [Install Caffe](http://caffe.berkeleyvision.org/install_osx.html)
+        * [Install Tensorflow](https://www.tensorflow.org/versions/r0.12/get_started/os_setup#virtualenv_installation)
+        * [Install Keras](https://keras.io/#installation)
+4. Install dependencies
+* For developers:
+    ```
+    pip install -r requirements/dev.txt
+    ```
+* Others:
+    ```
+    pip install -r requirements/common.txt
+    ```
+5. [Install postgres >= 9.5](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-postgresql-on-ubuntu-16-04)
+* Setup postgres database
+    * Start postgresql by typing ```sudo service postgresql start```
+    * Now login as user postgres by running ```sudo -u postgres psql``` and type the commands below
+    
+    ```
+      CREATE DATABASE fabrik;
+      CREATE USER admin WITH PASSWORD 'fabrik';
+      ALTER ROLE admin SET client_encoding TO 'utf8';
+      ALTER ROLE admin SET default_transaction_isolation TO 'read committed';
+      ALTER ROLE admin SET timezone TO 'UTC';
+      ALTER USER admin CREATEDB;
+    ```
+    * Exit psql by typing in \q and hitting enter. 
+* Migrate
+    ```
+    
+    python manage.py makemigrations caffe_app
+    python manage.py migrate
+    ```
+6. Install node modules
+```
+npm install
+webpack --progress --watch --colors
+```
+
+### Usage
+```
+KERAS_BACKEND=theano python manage.py runserver
+```
+
+### Example
+* Use `example/tensorflow/GoogleNet.pbtxt` for tensorflow import
+* Use `example/caffe/GoogleNet.prototxt` for caffe import
+* Use `example/keras/vgg16.json` for keras import

--- a/docs/source/tested_models.md
+++ b/docs/source/tested_models.md
@@ -1,0 +1,37 @@
+List of all models for which import/export has been tested with Fabrik.
+
+## Recognition
+
+* AlexNet [\[Source\]](https://github.com/BVLC/caffe/tree/master/models/bvlc_alexnet)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208113052pazsy)
+* All CNN [\[Source\]](https://github.com/mateuszbuda/ALL-CNN)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208113139kxufp)
+* CaffeNet [\[Source\]](https://github.com/BVLC/caffe/tree/master/models/bvlc_reference_caffenet)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208120646sxjld)
+* DenseNet [\[Source\]](https://github.com/liuzhuang13/DenseNet)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208113250okkxz)
+* GoogLeNet [\[Source\]](https://github.com/BVLC/caffe/tree/master/models/bvlc_googlenet)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208113226qdybn)
+* InceptionV3 [\[Source\]](https://github.com/fchollet/keras/blob/master/keras/applications/inception_v3.py)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208113344mfgdw)
+*  Network in Network [\[Source\]](https://github.com/BVLC/caffe/wiki/Model-Zoo#network-in-network-model)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208121158kdgdf)
+* ResNet-101 [\[Source\]](https://github.com/KaimingHe/deep-residual-networks)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208113311evllg)
+* SqueezeNet [\[Source\]](https://github.com/DeepScale/SqueezeNet)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208113403vkslv)
+* VGG-16 [\[Source\]](https://gist.github.com/ksimonyan/211839e770f7b538e2d8#file-readme-md)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208113208hjcvb)
+
+## Detection
+
+* FCN32 Pascal [\[Source\]](https://github.com/shelhamer/fcn.berkeleyvision.org)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208113426rgyqo)
+* RCNN [\[Source\]](https://github.com/rbgirshick/rcnn)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208120915yxabc)
+* YOLONet [\[Source\]](https://github.com/xingwangsfu/caffe-yolo)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208113441rfnbr)
+
+## Retrieval
+
+* MNIST Siamese [\[Source\]](https://github.com/BVLC/caffe/tree/master/examples/siamese)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208113503xgnfd)
+
+## Seq2Seq
+
+* Seq2Seq Translation [\[Source\]](https://github.com/fchollet/keras/blob/master/examples/lstm_seq2seq.py)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208115116hsfax)
+* Text Generation [\[Source\]](https://machinelearningmastery.com/text-generation-lstm-recurrent-neural-networks-python-keras/)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208113517iphlh)
+
+## Captioning
+
+* COCO Caption [\[Source\]](https://github.com/jeffdonahue/caffe/tree/recurrent-rebase-cleanup/examples/coco_caption)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208113707zcgth)
+* VQA [\[Source\]](https://github.com/iamaaditya/VQA_Demo)
+## Miscellaneous
+
+* Ranking CNN [\[Source\]](https://github.com/RankingCNN/Using-Ranking-CNN-for-Age-Estimation)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208121544acjpu)


### PR DESCRIPTION
Adds all available documentation to the fabrik's readthedocs site.
You can check the site of my fork here: http://fabrikdocs.readthedocs.io/

Related GCI Task: https://codein.withgoogle.com/dashboard/task-instances/5050072960073728/