### PR TITLE
Fix #188: Collapsibles' arrows

### DIFF
--- a/ide/static/js/pane.js
+++ b/ide/static/js/pane.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PaneElement from './paneElement';
+import $ from 'jquery'
 
 class Pane extends React.Component {
   constructor(props) {
@@ -17,9 +18,11 @@ class Pane extends React.Component {
             loss: false
         };
     }
-    toggleClass(layer) {
+    toggleClass() {
         var obj = {};
-        obj[layer] = !this.state[layer];
+        for (var entry in this.state) {
+            obj[entry] = $("#" + entry).attr("aria-expanded") === "true";
+        }
         this.setState(obj);
     }
     render(){


### PR DESCRIPTION
`toggleClass()` now iterates over all categories and sets the real state from `aria-expanded` attribute to each var in this.state.