### PR TITLE
Fix: title no longer overlaps with error messages, if any.

### DIFF
--- a/ide/static/css/style.css
+++ b/ide/static/css/style.css
@@ -530,7 +530,7 @@ input#netName.hidden {
     color: white;
     background-color: #f44336;
     border: none;
-    z-index: 22;
+    z-index: 120;
     position: absolute;
     top: 3%;
     left:30%;

--- a/ide/static/js/content.js
+++ b/ide/static/js/content.js
@@ -199,7 +199,7 @@ class Content extends React.Component {
       Object.keys(layer.params).forEach(param => {
         layer.params[param] = layer.params[param][0];
         const paramData = data[layer.info.type].params[param];
-        if (layer.info.type == 'Python' || param == 'endPoint'){
+        if (layer.info.type == 'Python' && param == 'endPoint'){
           return;
         }
         if (paramData.required === true && layer.params[param] === '') {

--- a/ide/static/js/content.js
+++ b/ide/static/js/content.js
@@ -743,7 +743,7 @@ class Content extends React.Component {
       layer.props = JSON.parse(JSON.stringify(next.props)) //copys all props from data.js
       const height = Math.round(0.05*window.innerHeight, 0); // 5% of screen height, rounded to zero decimals
       const width = Math.round(0.35*window.innerWidth, 0); // 35% of screen width, rounded to zero decimals
-      var top = height + Math.ceil(41-height);
+      var top = height + Math.ceil(100-height);
       var left = width;
       layer.state = {
             top: `${top}px`,

--- a/ide/static/js/content.js
+++ b/ide/static/js/content.js
@@ -199,7 +199,7 @@ class Content extends React.Component {
       Object.keys(layer.params).forEach(param => {
         layer.params[param] = layer.params[param][0];
         const paramData = data[layer.info.type].params[param];
-        if (layer.info.type == 'Python' && param == 'endPoint'){
+        if (layer.info.type == 'Python' || param == 'endPoint'){
           return;
         }
         if (paramData.required === true && layer.params[param] === '') {

--- a/ide/static/js/content.js
+++ b/ide/static/js/content.js
@@ -743,7 +743,7 @@ class Content extends React.Component {
       layer.props = JSON.parse(JSON.stringify(next.props)) //copys all props from data.js
       const height = Math.round(0.05*window.innerHeight, 0); // 5% of screen height, rounded to zero decimals
       const width = Math.round(0.35*window.innerWidth, 0); // 35% of screen width, rounded to zero decimals
-      var top = height + Math.ceil(100-height);
+      var top = height + Math.ceil(81-height);
       var left = width;
       layer.state = {
             top: `${top}px`,


### PR DESCRIPTION
Previous:

![errorbelowname](https://user-images.githubusercontent.com/5107795/34117938-44633e7c-e443-11e7-80d3-0a01a15c40f2.JPG)

Current:

![errorabovename](https://user-images.githubusercontent.com/5107795/34117987-724b7660-e443-11e7-8963-b31349edebc3.JPG)

