### PR TITLE
Fix #199: Cannot add layer after delete

### DIFF
--- a/ide/static/js/canvas.js
+++ b/ide/static/js/canvas.js
@@ -73,10 +73,24 @@ class Canvas extends React.Component {
     }
     // Might need to improve the logic of clickEvent
     if(Object.keys(net).length>1 && this.props.clickEvent){
-      const x1 = parseInt(net[`l${this.props.nextLayerId-2}`].state.top.split('px'));
-      const x2 = parseInt(net[`l${this.props.nextLayerId-1}`].state.top.split('px')); 
-      const s = instance.getEndpoints(`l${this.props.nextLayerId-2}`)[0];
-      var t = instance.getEndpoints(`l${this.props.nextLayerId-1}`);
+      for (let i = this.props.nextLayerId - 1; i >= 0; i --) { //find last layer id
+        if (net[`l${i}`] !== undefined) {
+          var lastLayerId = i;
+          break;
+        }
+      }
+      for (let i = lastLayerId - 1; i >= 0; i --) { //find second last layer id
+        if (net[`l${i}`] !== undefined) {
+          var prevLayerId = i;
+          break;
+        }
+      }
+      lastLayerId = `l${lastLayerId}`; //add 'l' ahead of the index
+      prevLayerId = `l${prevLayerId}`;
+      const x1 = parseInt(net[prevLayerId].state.top.split('px'));
+      const x2 = parseInt(net[lastLayerId].state.top.split('px')); 
+      const s = instance.getEndpoints(prevLayerId)[0];
+      var t = instance.getEndpoints(lastLayerId);
       // To handle case of loss layer being target
       if (t.length == 1){
         t = t[0];

--- a/ide/static/js/content.js
+++ b/ide/static/js/content.js
@@ -177,6 +177,9 @@ class Content extends React.Component {
     const net = this.state.net;
     const input = net[layerId].connection.input;
     const output = net[layerId].connection.output;
+    const layerIdNum = parseInt(layerId.substring(1,layerId.length)); //numeric value of the layerId
+    const nextLayerId = this.state.nextLayerId - 1 == layerIdNum ? layerIdNum : this.state.nextLayerId; 
+       //if last layer was deleted nextLayerId is replaced by deleted layer's id
     let index;
     delete net[layerId];
     input.forEach(inputId => {
@@ -187,7 +190,7 @@ class Content extends React.Component {
       index = net[outputId].connection.input.indexOf(layerId);
       net[outputId].connection.input.splice(index, 1);
     });
-    this.setState({ net, selectedLayer: null });
+    this.setState({ net, selectedLayer: null, nextLayerId: nextLayerId });
   }
   exportNet(framework) {
     this.dismissAllErrors();

--- a/ide/static/js/content.js
+++ b/ide/static/js/content.js
@@ -177,9 +177,6 @@ class Content extends React.Component {
     const net = this.state.net;
     const input = net[layerId].connection.input;
     const output = net[layerId].connection.output;
-    const layerIdNum = parseInt(layerId.substring(1,layerId.length)); //numeric value of the layerId
-    const nextLayerId = this.state.nextLayerId - 1 == layerIdNum ? layerIdNum : this.state.nextLayerId; 
-        //if last layer was deleted nextLayerId is replaced by deleted layer's id
     let index;
     delete net[layerId];
     input.forEach(inputId => {
@@ -190,7 +187,7 @@ class Content extends React.Component {
       index = net[outputId].connection.input.indexOf(layerId);
       net[outputId].connection.input.splice(index, 1);
     });
-    this.setState({ net, selectedLayer: null, nextLayerId: nextLayerId});
+    this.setState({ net, selectedLayer: null });
   }
   exportNet(framework) {
     this.dismissAllErrors();

--- a/ide/static/js/content.js
+++ b/ide/static/js/content.js
@@ -177,6 +177,9 @@ class Content extends React.Component {
     const net = this.state.net;
     const input = net[layerId].connection.input;
     const output = net[layerId].connection.output;
+    const layerIdNum = parseInt(layerId.substring(1,layerId.length)); //numeric value of the layerId
+    const nextLayerId = this.state.nextLayerId - 1 == layerIdNum ? layerIdNum : this.state.nextLayerId; 
+        //if last layer was deleted nextLayerId is replaced by deleted layer's id
     let index;
     delete net[layerId];
     input.forEach(inputId => {
@@ -187,7 +190,7 @@ class Content extends React.Component {
       index = net[outputId].connection.input.indexOf(layerId);
       net[outputId].connection.input.splice(index, 1);
     });
-    this.setState({ net, selectedLayer: null });
+    this.setState({ net, selectedLayer: null, nextLayerId: nextLayerId});
   }
   exportNet(framework) {
     this.dismissAllErrors();

--- a/ide/static/js/pane.js
+++ b/ide/static/js/pane.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PaneElement from './paneElement';
+import $ from 'jquery'
 
 class Pane extends React.Component {
   constructor(props) {
@@ -17,9 +18,11 @@ class Pane extends React.Component {
             loss: false
         };
     }
-    toggleClass(layer) {
+    toggleClass() {
         var obj = {};
-        obj[layer] = !this.state[layer];
+        for (var entry in this.state) {
+            obj[entry] = $("#" + entry).attr("aria-expanded") === "true";
+        }
         this.setState(obj);
     }
     render(){


### PR DESCRIPTION
There was a problem `deleteLayer()` in `content.js`. `nextLayerId` stayed the same even after the last layer was deleted. My fix substracts 1 from nextLayerId if last layer was deleted.

~~There are still some issues when layer in middle is deleted, you can't delete layers in the separated part of the net anymore. You can still add layers to the end tho.~~

edit: It's actually a problem of indexing. Some methods expected that the layers will be in a sequence (no index missing). Deleting a layer caused missing index which caused the bug.