### PR TITLE
Fix #198: Fabrik now works on Edge

### DIFF
--- a/caffe_app/views/import_prototxt.py
+++ b/caffe_app/views/import_prototxt.py
@@ -544,7 +544,8 @@ layer_dict = {'Accuracy': Accuracy,
 def import_prototxt(request):
     if request.method == 'POST':
         if ('file' in request.FILES) and \
-           (request.FILES['file'].content_type == 'application/octet-stream'):
+           (request.FILES['file'].content_type == 'application/octet-stream' or \
+            request.FILES['file'].content_type == 'text/plain'):
             try:
                 prototxt = request.FILES['file']
             except Exception:

--- a/caffe_app/views/import_prototxt.py
+++ b/caffe_app/views/import_prototxt.py
@@ -544,8 +544,8 @@ layer_dict = {'Accuracy': Accuracy,
 def import_prototxt(request):
     if request.method == 'POST':
         if ('file' in request.FILES) and \
-           (request.FILES['file'].content_type == 'application/octet-stream' or \
-            request.FILES['file'].content_type == 'text/plain'):
+           (request.FILES['file'].content_type == 'application/octet-stream' or
+                request.FILES['file'].content_type == 'text/plain'):
             try:
                 prototxt = request.FILES['file']
             except Exception:

--- a/ide/static/css/style.css
+++ b/ide/static/css/style.css
@@ -530,7 +530,7 @@ input#netName.hidden {
     color: white;
     background-color: #f44336;
     border: none;
-    z-index: 22;
+    z-index: 120;
     position: absolute;
     top: 3%;
     left:30%;

--- a/ide/static/js/canvas.js
+++ b/ide/static/js/canvas.js
@@ -204,7 +204,7 @@ class Canvas extends React.Component {
     const canvas = document.getElementById('jsplumbContainer');
     const zoom = instance.getZoom();
 
-    const type = event.dataTransfer.getData('element_type');
+    const type = this.props.draggingLayer;
     if (data[type].learn && (this.props.selectedPhase === 1)) {
       this.props.addError(`Error: you can not add a "${type}" layer in test phase`);
     } else {
@@ -237,6 +237,7 @@ class Canvas extends React.Component {
       layer.props.name = `${data[type].name}${this.props.nextLayerId}`;
       this.props.addNewLayer(layer);
     }
+    this.props.setDraggingLayer(null);
   }
   render() {
     const layers = [];
@@ -357,7 +358,9 @@ Canvas.propTypes = {
   error: React.PropTypes.array,
   placeholder: React.PropTypes.bool,
   clickEvent: React.PropTypes.bool,
-  totalParameters: React.PropTypes.number
+  totalParameters: React.PropTypes.number,
+  setDraggingLayer: React.PropTypes.func,
+  draggingLayer: React.PropTypes.string
 };
 
 export default Canvas;

--- a/ide/static/js/content.js
+++ b/ide/static/js/content.js
@@ -32,6 +32,7 @@ class Content extends React.Component {
     this.state = {
       net: {},
       net_name: 'Untitled',
+      draggingLayer: null,
       selectedLayer: null,
       hoveredLayer: null,
       nextLayerId: 0,
@@ -47,6 +48,7 @@ class Content extends React.Component {
     this.changeHoveredLayer = this.changeHoveredLayer.bind(this);
     this.componentWillMount = this.componentWillMount.bind(this);
     this.modifyLayer = this.modifyLayer.bind(this);
+    this.setDraggingLayer = this.setDraggingLayer.bind(this);
     this.changeNetName = this.changeNetName.bind(this);
     this.adjustParameters = this.adjustParameters.bind(this);
     this.modifyLayerParams = this.modifyLayerParams.bind(this);
@@ -541,6 +543,9 @@ class Content extends React.Component {
       });
     }
   }
+  setDraggingLayer(id) {
+    this.setState({ draggingLayer: id })
+  }
   changeNetName(event) {
     this.setState({net_name: event.target.value});
   }
@@ -876,6 +881,7 @@ class Content extends React.Component {
              <h5 className="sidebar-heading">INSERT LAYER</h5>
              <Pane 
              handleClick = {this.handleClick}
+             setDraggingLayer = {this.setDraggingLayer}
              />
              <div className="text-center">
               <Tabs selectedPhase={this.state.selectedPhase} changeNetPhase={this.changeNetPhase} />
@@ -898,7 +904,6 @@ class Content extends React.Component {
           {loader}
           <Canvas
             net={this.state.net}
-            selectedPhase={this.state.selectedPhase}
             rebuildNet={this.state.rebuildNet}
             addNewLayer={this.addNewLayer}
             nextLayerId={this.state.nextLayerId}
@@ -911,6 +916,9 @@ class Content extends React.Component {
             addError={this.addError}
             clickEvent={this.clickEvent}
             totalParameters={this.state.totalParameters}
+            selectedPhase={this.state.selectedPhase}
+            draggingLayer={this.state.draggingLayer}
+            setDraggingLayer={this.setDraggingLayer}
           />
           <SetParams
             net={this.state.net}

--- a/ide/static/js/content.js
+++ b/ide/static/js/content.js
@@ -199,7 +199,7 @@ class Content extends React.Component {
       Object.keys(layer.params).forEach(param => {
         layer.params[param] = layer.params[param][0];
         const paramData = data[layer.info.type].params[param];
-        if (layer.info.type == 'Python' || param == 'endPoint'){
+        if (layer.info.type == 'Python' && param == 'endPoint'){
           return;
         }
         if (paramData.required === true && layer.params[param] === '') {

--- a/ide/static/js/content.js
+++ b/ide/static/js/content.js
@@ -199,7 +199,7 @@ class Content extends React.Component {
       Object.keys(layer.params).forEach(param => {
         layer.params[param] = layer.params[param][0];
         const paramData = data[layer.info.type].params[param];
-        if (layer.info.type == 'Python' && param == 'endPoint'){
+        if (layer.info.type == 'Python' || param == 'endPoint'){
           return;
         }
         if (paramData.required === true && layer.params[param] === '') {

--- a/ide/static/js/pane.js
+++ b/ide/static/js/pane.js
@@ -39,15 +39,33 @@ class Pane extends React.Component {
                 </div>
                 <div id="data" className="panel-collapse collapse" role=" tabpanel">
                   <div className="panel-body">
-                    <PaneElement handleClick={this.props.handleClick} id="ImageData">Image Data</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Data">Data</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="HDF5Data">HDF5 Data</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="HDF5Output">HDF5 Output</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Input">Input</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="WindowData">Window Data</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="MemoryData">Memory Data</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="DummyData">Dummy Data</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Python">Python</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="ImageData">Image Data</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Data">Data</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="HDF5Data">HDF5 Data</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="HDF5Output">HDF5 Output</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Input">Input</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="WindowData">Window Data</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="MemoryData">Memory Data</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="DummyData">Dummy Data</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Python">Python</PaneElement>
                   </div>
                 </div>
               </div>
@@ -62,13 +80,27 @@ class Pane extends React.Component {
                 </div>
                 <div id="vision" className="panel-collapse collapse" role="tabpanel">
                   <div className="panel-body">
-                    <PaneElement handleClick={this.props.handleClick} id="Convolution">Convolution</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Pooling">Pool</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Upsample">Upsample</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="LocallyConnected">Locally Connected</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Crop">Crop</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="SPP">SPP</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Deconvolution">Deconvolution</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Convolution">Convolution</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Pooling">Pool</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Upsample">Upsample</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="LocallyConnected">Locally Connected</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Crop">Crop</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="SPP">SPP</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Deconvolution">Deconvolution</PaneElement>
                   </div>
                 </div>
               </div>
@@ -83,10 +115,18 @@ class Pane extends React.Component {
                 </div>
                 <div id="recurrent" className="panel-collapse collapse" role="tabpanel">
                   <div className="panel-body">
-                    <PaneElement handleClick={this.props.handleClick} id="Recurrent">Recurrent</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="RNN">RNN</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="GRU">GRU</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="LSTM">LSTM</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Recurrent">Recurrent</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="RNN">RNN</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="GRU">GRU</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="LSTM">LSTM</PaneElement>
                   </div>
                 </div>
               </div>
@@ -101,21 +141,51 @@ class Pane extends React.Component {
                 </div>
                 <div id="utility" className="panel-collapse collapse" role="tabpanel">
                   <div className="panel-body">
-                    <PaneElement handleClick={this.props.handleClick} id="Flatten">Flatten</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Reshape">Reshape</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="BatchReindex">Batch Reindex</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Split">Split</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Concat">Concat</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Eltwise">Eltwise</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Filter">Filter</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Reduction">Reduction</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Silence">Silence</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="ArgMax">ArgMax</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Softmax">Softmax</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Permute">Permute</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="RepeatVector">Repeat Vector</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Regularization">Regularization</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Masking">Masking</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Flatten">Flatten</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Reshape">Reshape</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="BatchReindex">Batch Reindex</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Split">Split</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Concat">Concat</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Eltwise">Eltwise</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Filter">Filter</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Reduction">Reduction</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Silence">Silence</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="ArgMax">ArgMax</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Softmax">Softmax</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Permute">Permute</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="RepeatVector">Repeat Vector</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Regularization">Regularization</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Masking">Masking</PaneElement>
                   </div>
                 </div>
               </div>
@@ -130,24 +200,60 @@ class Pane extends React.Component {
                 </div>
                 <div id="activation" className="panel-collapse collapse" role="tabpanel">
                   <div className="panel-body">
-                    <PaneElement handleClick={this.props.handleClick} id="ReLU">ReLU/Leaky-ReLU</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="PReLU">PReLU</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="ELU">ELU</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="ThresholdedReLU">Thresholded ReLU</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="SELU">SELU</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Softplus">Softplus</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Softsign">Softsign</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Sigmoid">Sigmoid</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="TanH">TanH</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="HardSigmoid">Hard Sigmoid</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="AbsVal">Absolute Value</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Power">Power</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Exp">Exp</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Log">Log</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="BNLL">BNLL</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Threshold">Threshold</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Bias">Bias</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Scale">Scale</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="ReLU">ReLU/Leaky-ReLU</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="PReLU">PReLU</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="ELU">ELU</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="ThresholdedReLU">Thresholded ReLU</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="SELU">SELU</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Softplus">Softplus</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Softsign">Softsign</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Sigmoid">Sigmoid</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="TanH">TanH</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="HardSigmoid">Hard Sigmoid</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="AbsVal">Absolute Value</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Power">Power</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Exp">Exp</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Log">Log</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="BNLL">BNLL</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Threshold">Threshold</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Bias">Bias</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Scale">Scale</PaneElement>
                   </div>
                 </div>
               </div>
@@ -162,9 +268,15 @@ class Pane extends React.Component {
                 </div>
                 <div id="normalization" className="panel-collapse collapse" role="tabpanel">
                   <div className="panel-body">
-                    <PaneElement handleClick={this.props.handleClick} id="LRN">LRN</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="MVN">MVN</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="BatchNorm">Batch Norm</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="LRN">LRN</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="MVN">MVN</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="BatchNorm">Batch Norm</PaneElement>
                   </div>
                 </div>
               </div>
@@ -179,9 +291,15 @@ class Pane extends React.Component {
                 </div>
                 <div id="common" className="panel-collapse collapse" role="tabpanel">
                   <div className="panel-body">
-                    <PaneElement handleClick={this.props.handleClick} id="InnerProduct">Inner Product</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Dropout">Dropout</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Embed">Embed</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="InnerProduct">Inner Product</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Dropout">Dropout</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Embed">Embed</PaneElement>
                   </div>
                 </div>
               </div>
@@ -196,9 +314,15 @@ class Pane extends React.Component {
                 </div>
                 <div id="noise" className="panel-collapse collapse" role="tabpanel">
                   <div className="panel-body">
-                    <PaneElement handleClick={this.props.handleClick} id="GaussianNoise">Gaussian Noise</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="GaussianDropout">Gaussian Dropout</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="AlphaDropout">Alpha Dropout</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="GaussianNoise">Gaussian Noise</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="GaussianDropout">Gaussian Dropout</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="AlphaDropout">Alpha Dropout</PaneElement>
                   </div>
                 </div>
               </div>
@@ -213,15 +337,33 @@ class Pane extends React.Component {
                 </div>
                 <div id="loss" className="panel-collapse collapse" role="tabpanel">
                   <div className="panel-body">
-                    <PaneElement handleClick={this.props.handleClick} id="MultinomialLogisticLoss">Multinomial Logistic Loss</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="InfogainLoss">Infogain Loss</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="SoftmaxWithLoss">Softmax With Loss</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="EuclideanLoss">Euclidean Loss</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="HingeLoss">Hinge Loss</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="SigmoidCrossEntropyLoss">Sigmoid Cross Entropy Loss</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Accuracy">Accuracy</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="ContrastiveLoss">Contrastive Loss</PaneElement>
-                    <PaneElement handleClick={this.props.handleClick} id="Python">Python</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="MultinomialLogisticLoss">Multinomial Logistic Loss</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="InfogainLoss">Infogain Loss</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="SoftmaxWithLoss">Softmax With Loss</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="EuclideanLoss">Euclidean Loss</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="HingeLoss">Hinge Loss</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="SigmoidCrossEntropyLoss">Sigmoid Cross Entropy Loss</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Accuracy">Accuracy</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="ContrastiveLoss">Contrastive Loss</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Python">Python</PaneElement>
                   </div>
                 </div>
               </div>
@@ -232,6 +374,7 @@ class Pane extends React.Component {
   }
 }
 Pane.propTypes = {
-  handleClick: React.PropTypes.func.isRequired
+  handleClick: React.PropTypes.func.isRequired,
+  setDraggingLayer: React.PropTypes.func.isRequired
 };
 export default Pane;

--- a/ide/static/js/paneElement.js
+++ b/ide/static/js/paneElement.js
@@ -6,7 +6,7 @@ class PaneElement extends React.Component {
     this.drag = this.drag.bind(this);
   }
   drag(e) {
-    e.dataTransfer.setData('element_type', e.target.id);
+    this.props.setDraggingLayer(e.target.id);
   }
   render() {
     return (
@@ -26,7 +26,8 @@ class PaneElement extends React.Component {
 PaneElement.propTypes = {
   id: React.PropTypes.string.isRequired,
   children: React.PropTypes.string.isRequired,
-  handleClick: React.PropTypes.func.isRequired
+  handleClick: React.PropTypes.func.isRequired,
+  setDraggingLayer: React.PropTypes.func.isRequired
 };
 
 export default PaneElement;


### PR DESCRIPTION
**Issue 1: Dragging/dropping layers did not work:**

This issue was caused due to the spec set for setData/getData in drag-drop events, where the data is stored in a "protected mode", ie. no event other than the original one is allowed to access it. Firefox and Chrome don't follow the W3C spec so setData/getData works there, but Edge follows the spec and doesn't allow it.

More info here: https://stackoverflow.com/questions/11927309/html5-dnd-datatransfer-setdata-or-getdata-not-working-in-every-browser-except-fi

The most effective solution is to just use a different means of storing what is being dragged or dropped, so I used a React state variable.

**Issue 2: Models could not be imported from file:**

This seems to have been caused due to the fact that while every other browser sends a .prototxt file with content-type application/octet-stream, Edge sends it with text/plain. Simply allowing text/plain files to be imported as models works, and invalid files will still be caught by the try/except blocks.