### PR TITLE
Feature Addition: Delete Selected Layers by pressing delete key

### DIFF
--- a/ide/static/js/setParams.js
+++ b/ide/static/js/setParams.js
@@ -102,7 +102,7 @@ class SetParams extends React.Component {
       return (
         <div className="setparams setparamsActive" >
           <div className="setHead">
-            <h5 className="sidebar-heading">LAYEEER SELECTED</h5>
+            <h5 className="sidebar-heading">LAYER SELECTED</h5>
             <h4>{layer.props.name}</h4>
             <span className="glyphicon glyphicon-remove-sign closeSign" onClick={() => this.close()} aria-hidden="true"></span>
           </div>

--- a/ide/static/js/setParams.js
+++ b/ide/static/js/setParams.js
@@ -9,6 +9,7 @@ class SetParams extends React.Component {
     this.changeProps = this.changeProps.bind(this);
     this.trainOnly = this.trainOnly.bind(this);
     this.close = this.close.bind(this);
+    this.handleKeyPress = this.handleKeyPress.bind(this);
   }
   changeProps(prop, value) {
     const net = this.props.net;
@@ -31,6 +32,17 @@ class SetParams extends React.Component {
     if (e.target.checked) {
       this.props.trainOnly();
     }
+  }
+  handleKeyPress(event){
+     if (event.key == 'Delete'){
+      this.props.deleteLayer(this.props.selectedLayer);
+    }
+  }
+  componentDidMount(){
+    document.addEventListener("keydown", this.handleKeyPress, false);
+  }
+  componentWillUnmount(){
+    document.removeEventListener("keydown", this.handleKeyPress, false);
   }
   render() {
     if (this.props.selectedLayer) {
@@ -89,9 +101,8 @@ class SetParams extends React.Component {
 
       return (
         <div className="setparams setparamsActive" >
-
           <div className="setHead">
-            <h5 className="sidebar-heading">LAYER SELECTED</h5>
+            <h5 className="sidebar-heading">LAYEEER SELECTED</h5>
             <h4>{layer.props.name}</h4>
             <span className="glyphicon glyphicon-remove-sign closeSign" onClick={() => this.close()} aria-hidden="true"></span>
           </div>


### PR DESCRIPTION
Deleting a lot of layers can get annoying because we have to select each one and click the delete layer button. 

I made this process more convenient, and now pressing the delete key with a layer selected will delete that layer. 