### PR TITLE
Fix #285: nondescript 'dim' error removed

### DIFF
--- a/ide/utils/shapes.py
+++ b/ide/utils/shapes.py
@@ -2,19 +2,22 @@ import numpy as np
 
 
 def data(layer):
-    Input = []
-    if (layer['info']['type'] in ['ImageData', 'Data', 'WindowData']):
-        if (('crop_size' in layer['params']) and (layer['params']['crop_size'] != 0)):
-            Output = [3] + [layer['params']['crop_size']]*2
-        elif (('new_height' in layer['params']) and ('new_width' in layer['params'])):
-            Output = [3, layer['params']['new_height'], layer['params']['new_width']]
-    elif (layer['info']['type'] in ['Input', 'DummyData']):
-        Output = map(int, layer['params']['dim'].split(','))[1:]
-    elif (layer['info']['type'] == 'MemoryData'):
-        Output = [3, layer['params']['height'], layer['params']['width']]
-    else:
+    try:
+        Input = []
+        if (layer['info']['type'] in ['ImageData', 'Data', 'WindowData']):
+            if (('crop_size' in layer['params']) and (layer['params']['crop_size'] != 0)):
+                Output = [3] + [layer['params']['crop_size']]*2
+            elif (('new_height' in layer['params']) and ('new_width' in layer['params'])):
+                Output = [3, layer['params']['new_height'], layer['params']['new_width']]
+        elif (layer['info']['type'] in ['Input', 'DummyData']):
+            Output = map(int, layer['params']['dim'].split(','))[1:]
+        elif (layer['info']['type'] == 'MemoryData'):
+            Output = [3, layer['params']['height'], layer['params']['width']]
+        else:
+            raise Exception('Cannot determine shape of ' + layer['info']['type'] + ' layer.')
+        return Input, Output
+    except BaseException:
         raise Exception('Cannot determine shape of ' + layer['info']['type'] + ' layer.')
-    return Input, Output
 
 
 def identity(layer):

--- a/ide/utils/shapes.py
+++ b/ide/utils/shapes.py
@@ -1,16 +1,16 @@
 import numpy as np
 
-
 def data(layer):
     try:
         Input = []
         if (layer['info']['type'] in ['ImageData', 'Data', 'WindowData']):
-            if (('crop_size' in layer['params']) and (layer['params']['crop_size'] != 0)):
+            if ('crop_size' in layer['params']):
                 Output = [3] + [layer['params']['crop_size']]*2
             elif (('new_height' in layer['params']) and ('new_width' in layer['params'])):
                 Output = [3, layer['params']['new_height'], layer['params']['new_width']]
         elif (layer['info']['type'] in ['Input', 'DummyData']):
-            Output = map(int, layer['params']['dim'].split(','))[1:]
+            dim = layer['params']['dim'] or '0'
+            Output = map(int, dim.split(','))[1:]
         elif (layer['info']['type'] == 'MemoryData'):
             Output = [3, layer['params']['height'], layer['params']['width']]
         else:

--- a/ide/views.py
+++ b/ide/views.py
@@ -39,9 +39,8 @@ def fetch_layer_shape(request):
             # Obtain output shape of new layer
             if (net[layerId]['info']['type'] in dataLayers):
                 # handling Data Layers separately
-                if (len(net[layerId]['params']['dim'])):
-                    net[layerId]['shape']['input'], net[layerId]['shape']['output'] =\
-                            get_layer_shape(net[layerId])
+                net[layerId]['shape']['input'], net[layerId]['shape']['output'] =\
+                        get_layer_shape(net[layerId])
             else:
                 if (net[layerId]['shape']['input']):
                     net[layerId]['shape']['output'] = get_layer_shape(net[layerId])


### PR DESCRIPTION
Some data layers don't have a Dim property, and checking for them fails. However, the data(layer) function in ide/utils/shapes.py, which these layers end up running through, has thorough checking for all data layer types, so this just lets that function handle the checks, and raises a suitable exception if a property is missing.

@Ram81 Suggestions/improvements welcome.