### PR TITLE
Fix: Replace dead link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ KERAS_BACKEND=theano python manage.py runserver
 * [Using an Exported Caffe Model](https://github.com/Cloud-CV/Fabrik/blob/master/tutorials/caffe_prototxt_usage_1.md)
 * [Loading a caffe model in python and printing its parameters and output size](https://github.com/Cloud-CV/Fabrik/blob/master/tutorials/caffe_prototxt_usage_2.md)
 * [List of models tested with Fabrik](https://github.com/Cloud-CV/Fabrik/blob/master/tutorials/tested_models.md)
-* [Adding model to the Fabrik model zoo](https://github.com/Cloud-CV/Fabrik/blob/master/tutorials/AddingNewModel.md)
+* [Adding model to the Fabrik model zoo](https://github.com/Cloud-CV/Fabrik/blob/master/tutorials/addng_new_model.md)
 * [Adding new layers](https://github.com/Cloud-CV/Fabrik/blob/master/tutorials/adding_new_layers.md)
 * [Linux installation walk-through](https://www.youtube.com/watch?v=zPgoben9D1w)
 


### PR DESCRIPTION
Updated the link to the "Adding new model" guide, it was pointing to an old, defunct link.