### PR TITLE
Fix #306:changed shellscript to append new entries into `bash_profile` instead of wiping and rewriting the file

### DIFF
--- a/requirements/caffe_tensorflow_keras_install.sh
+++ b/requirements/caffe_tensorflow_keras_install.sh
@@ -27,7 +27,7 @@ if [ ! -d $HOME/caffe/caffe ]; then
 		cmake -DCPU_ONLY=1 -DBUILD_python_layer=1 ..
 		make -j"$(nproc)"
 		
-		echo "export PYTHONPATH=$PYTHONPATH:$HOME/caffe/caffe/python" > ~/.bash_profile
+		echo "export PYTHONPATH=$PYTHONPATH:$HOME/caffe/caffe/python" >> ~/.bash_profile
 fi
 echo "#################### Caffe Install Complete! ####################"
 


### PR DESCRIPTION

fixes #306 

shellscript wipe present entries in bash_profile while setting PYTHONPATH, modifying it to only append at the end of bash_profile instead of deleting present entries.
