### PR TITLE
Keras TF Backend Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
 
 before_script:
   - export PYTHONPATH=$PYTHONPATH:$HOME/caffe/caffe/python
+  - export LD_PRELOAD="/usr/lib/libtcmalloc.so.4"
   - psql -c "CREATE DATABASE fabrik" -U postgres
   - psql -c "CREATE USER admin WITH PASSWORD 'fabrik'" -U postgres
   - psql -c "ALTER ROLE admin SET client_encoding TO 'utf8'" -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
 script:
   - flake8 ./
   - npm run ci
-  - KERAS_BACKEND=theano coverage run --source=caffe_app,keras_app,ide/utils manage.py test
+  - coverage run --source=caffe_app,keras_app,ide/utils manage.py test
 
 after_success:
   - coveralls

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ webpack --progress --watch --colors
 
 ### Usage
 ```
-KERAS_BACKEND=theano python manage.py runserver
+python manage.py runserver
 ```
 
 ### Example

--- a/requirements/caffe_tensorflow_keras_install.sh
+++ b/requirements/caffe_tensorflow_keras_install.sh
@@ -32,7 +32,8 @@ fi
 echo "#################### Caffe Install Complete! ####################"
 
 echo "Installing Tensorflow dependencies"
-sudo apt-get install python-pip python-dev
+sudo apt-get install python-pip python-dev google-perftools
+export LD_PRELOAD="/usr/lib/libtcmalloc.so.4" 
 
 echo "Installing Tensorflow"
 pip install tensorflow==1.4.1

--- a/requirements/caffe_tensorflow_keras_install.sh
+++ b/requirements/caffe_tensorflow_keras_install.sh
@@ -40,9 +40,6 @@ pip install tensorflow==1.4.1
 
 echo "#################### Tensorflow Install Complete! ####################"
 
-echo "Installing Theano"
-pip install theano==0.9.0
-
 echo "Installing Keras"
 pip install keras==2.0.8
 

--- a/tensorflow_app/views/import_graphdef.py
+++ b/tensorflow_app/views/import_graphdef.py
@@ -97,6 +97,7 @@ def import_graph_def(request):
         else:
             return JsonResponse({'result': 'error', 'error': 'No GraphDef model found'})
 
+        tf.reset_default_graph()
         graph_def = graph_pb2.GraphDef()
         d = {}
         order = []
@@ -154,9 +155,9 @@ def import_graph_def(request):
             name = get_layer_name(node.name)
             layer = d[name]
             if layer['type'][0] == 'Input':
-                # NCHW to NWHC data format
+                # NHWC data format
                 layer['params']['dim'] = str(map(int, [node.get_attr('shape').dim[i].size
-                                                       for i in [0, 3, 1, 2]]))[1:-1]
+                                                       for i in [0, 1, 2, 3]]))[1:-1]
 
             elif layer['type'][0] == 'Convolution':
                 if str(node.name) == name + '/weights' or str(node.name) == name + '/kernel':

--- a/tests/unit/keras_app/test_views.py
+++ b/tests/unit/keras_app/test_views.py
@@ -25,6 +25,7 @@ from keras.layers import GaussianNoise, GaussianDropout, AlphaDropout
 from keras.layers import Input
 from keras import regularizers
 from keras.models import Model, Sequential
+from keras import backend as K
 from keras_app.views.layers_export import data, convolution, deconvolution, \
     pooling, dense, dropout, embed, recurrent, batch_norm, activation, \
     flatten, reshape, eltwise, concat, upsample, locally_connected, permute, \
@@ -146,6 +147,23 @@ class ExportJsonTest(unittest.TestCase):
                                                               'net_name': ''})
         response = json.loads(response.content)
         self.assertEqual(response['result'], 'error')
+
+
+# *********** Keras Backend Test **********
+class KerasBackendTest(unittest.TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_keras_backend(self):
+        dim_order = K.image_dim_ordering()
+        backend = K.backend()
+        if(backend == 'tensorflow'):
+            self.assertEqual(dim_order, 'tf')
+        elif(backend == 'theano'):
+            self.assertNotEqual(dim_order, 'th')
+            self.assertEqual(dim_order, 'tf')
+        else:
+            self.fail('%s backend not supported' % backend)
 
 
 # ********** Import json tests **********
@@ -274,7 +292,7 @@ class DropoutImportTest(unittest.TestCase, HelperFunctions):
 
     def test_keras_import(self):
         model = Sequential()
-        model.add(Dropout(0.5, input_shape=(10, 64)))
+        model.add(Dropout(0.5, input_shape=(64, 10)))
         model.build()
         self.keras_type_test(model, 0, 'Dropout')
 
@@ -285,7 +303,7 @@ class FlattenImportTest(unittest.TestCase, HelperFunctions):
 
     def test_keras_import(self):
         model = Sequential()
-        model.add(Flatten(input_shape=(10, 64)))
+        model.add(Flatten(input_shape=(64, 10)))
         model.build()
         self.keras_type_test(model, 0, 'Flatten')
 
@@ -307,7 +325,7 @@ class PermuteImportTest(unittest.TestCase, HelperFunctions):
 
     def test_keras_import(self):
         model = Sequential()
-        model.add(Permute((2, 1), input_shape=(10, 64)))
+        model.add(Permute((2, 1), input_shape=(64, 10)))
         model.build()
         self.keras_type_test(model, 0, 'Permute')
 
@@ -340,7 +358,7 @@ class MaskingImportTest(unittest.TestCase, HelperFunctions):
 
     def test_keras_import(self):
         model = Sequential()
-        model.add(Masking(mask_value=0., input_shape=(5, 100)))
+        model.add(Masking(mask_value=0., input_shape=(100, 5)))
         model.build()
         self.keras_type_test(model, 0, 'Masking')
 
@@ -353,10 +371,10 @@ class ConvolutionImportTest(unittest.TestCase, HelperFunctions):
     def test_keras_import(self):
         # Conv 1D
         model = Sequential()
-        model.add(Conv1D(32, 3, kernel_regularizer=regularizers.l2(0.01),
+        model.add(Conv1D(32, 10, kernel_regularizer=regularizers.l2(0.01),
                          bias_regularizer=regularizers.l2(0.01),
                          activity_regularizer=regularizers.l2(0.01), kernel_constraint='max_norm',
-                         bias_constraint='max_norm', activation='relu', input_shape=(1, 16)))
+                         bias_constraint='max_norm', activation='relu', input_shape=(10, 1)))
         model.build()
         self.keras_param_test(model, 1, 9)
         # Conv 2D
@@ -364,7 +382,7 @@ class ConvolutionImportTest(unittest.TestCase, HelperFunctions):
         model.add(Conv2D(32, (3, 3), kernel_regularizer=regularizers.l2(0.01),
                          bias_regularizer=regularizers.l2(0.01),
                          activity_regularizer=regularizers.l2(0.01), kernel_constraint='max_norm',
-                         bias_constraint='max_norm', activation='relu', input_shape=(1, 16, 16)))
+                         bias_constraint='max_norm', activation='relu', input_shape=(16, 16, 1)))
         model.build()
         self.keras_param_test(model, 1, 13)
         # Conv 3D
@@ -372,7 +390,7 @@ class ConvolutionImportTest(unittest.TestCase, HelperFunctions):
         model.add(Conv3D(32, (3, 3, 3), kernel_regularizer=regularizers.l2(0.01),
                          bias_regularizer=regularizers.l2(0.01),
                          activity_regularizer=regularizers.l2(0.01), kernel_constraint='max_norm',
-                         bias_constraint='max_norm', activation='relu', input_shape=(1, 16, 16, 16)))
+                         bias_constraint='max_norm', activation='relu', input_shape=(16, 16, 16, 1)))
         model.build()
         self.keras_param_test(model, 1, 17)
 
@@ -382,7 +400,6 @@ class ConvolutionImportTest(unittest.TestCase, HelperFunctions):
 class DepthwiseConvolutionImportTest(unittest.TestCase, HelperFunctions):
     def setUp(self):
         self.client = Client()
-
     def test_keras_import(self):
         model = Sequential()
         model.add(SeparableConv2D(32, 3, depthwise_regularizer=regularizers.l2(0.01),
@@ -403,7 +420,7 @@ class DeconvolutionImportTest(unittest.TestCase, HelperFunctions):
         model.add(Conv2DTranspose(32, (3, 3), kernel_regularizer=regularizers.l2(0.01),
                                   bias_regularizer=regularizers.l2(0.01),
                                   activity_regularizer=regularizers.l2(0.01), kernel_constraint='max_norm',
-                                  bias_constraint='max_norm', activation='relu', input_shape=(1, 16, 16)))
+                                  bias_constraint='max_norm', activation='relu', input_shape=(16, 16, 1)))
         model.build()
         self.keras_param_test(model, 1, 13)
 
@@ -415,17 +432,17 @@ class UpsampleImportTest(unittest.TestCase, HelperFunctions):
     def test_keras_import(self):
         # Upsample 1D
         model = Sequential()
-        model.add(UpSampling1D(size=2, input_shape=(1, 16)))
+        model.add(UpSampling1D(size=2, input_shape=(16, 1)))
         model.build()
         self.keras_param_test(model, 0, 2)
         # Upsample 2D
         model = Sequential()
-        model.add(UpSampling2D(size=(2, 2), input_shape=(1, 16, 16)))
+        model.add(UpSampling2D(size=(2, 2), input_shape=(16, 16, 1)))
         model.build()
         self.keras_param_test(model, 0, 3)
         # Upsample 3D
         model = Sequential()
-        model.add(UpSampling3D(size=(2, 2, 2), input_shape=(1, 16, 16, 16)))
+        model.add(UpSampling3D(size=(2, 2, 2), input_shape=(16, 16, 16, 1)))
         model.build()
         self.keras_param_test(model, 0, 4)
 
@@ -438,28 +455,28 @@ class PoolingImportTest(unittest.TestCase, HelperFunctions):
     def test_keras_import(self):
         # Global Pooling 1D
         model = Sequential()
-        model.add(GlobalMaxPooling1D(input_shape=(1, 16)))
+        model.add(GlobalMaxPooling1D(input_shape=(16, 1)))
         model.build()
         self.keras_param_test(model, 0, 5)
         # Global Pooling 2D
         model = Sequential()
-        model.add(GlobalMaxPooling2D(input_shape=(1, 16, 16)))
+        model.add(GlobalMaxPooling2D(input_shape=(16, 16, 1)))
         model.build()
         self.keras_param_test(model, 0, 8)
         # Pooling 1D
         model = Sequential()
-        model.add(MaxPooling1D(pool_size=2, strides=2, padding='same', input_shape=(1, 16)))
+        model.add(MaxPooling1D(pool_size=2, strides=2, padding='same', input_shape=(16, 1)))
         model.build()
         self.keras_param_test(model, 0, 5)
         # Pooling 2D
         model = Sequential()
-        model.add(MaxPooling2D(pool_size=(2, 2), strides=(2, 2), padding='same', input_shape=(1, 16, 16)))
+        model.add(MaxPooling2D(pool_size=(2, 2), strides=(2, 2), padding='same', input_shape=(16, 16, 1)))
         model.build()
         self.keras_param_test(model, 0, 8)
         # Pooling 3D
         model = Sequential()
         model.add(MaxPooling3D(pool_size=(2, 2, 2), strides=(2, 2, 2), padding='same',
-                               input_shape=(1, 16, 16, 16)))
+                               input_shape=(16, 16, 16, 1)))
         model.build()
         self.keras_param_test(model, 0, 11)
 
@@ -475,7 +492,7 @@ class LocallyConnectedImportTest(unittest.TestCase, HelperFunctions):
         model.add(LocallyConnected1D(32, 3, kernel_regularizer=regularizers.l2(0.01),
                                      bias_regularizer=regularizers.l2(0.01),
                                      activity_regularizer=regularizers.l2(0.01), kernel_constraint='max_norm',
-                                     bias_constraint='max_norm', activation='relu', input_shape=(10, 16)))
+                                     bias_constraint='max_norm', activation='relu', input_shape=(16, 10)))
         model.build()
         self.keras_param_test(model, 1, 12)
         # Conv 2D
@@ -483,7 +500,7 @@ class LocallyConnectedImportTest(unittest.TestCase, HelperFunctions):
         model.add(LocallyConnected2D(32, (3, 3), kernel_regularizer=regularizers.l2(0.01),
                                      bias_regularizer=regularizers.l2(0.01),
                                      activity_regularizer=regularizers.l2(0.01), kernel_constraint='max_norm',
-                                     bias_constraint='max_norm', activation='relu', input_shape=(10, 16, 16)))
+                                     bias_constraint='max_norm', activation='relu', input_shape=(16, 16, 10)))
         model.build()
         self.keras_param_test(model, 1, 14)
 
@@ -563,7 +580,7 @@ class BatchNormImportTest(unittest.TestCase):
         model.add(BatchNormalization(center=True, scale=True, beta_regularizer=regularizers.l2(0.01),
                                      gamma_regularizer=regularizers.l2(0.01),
                                      beta_constraint='max_norm', gamma_constraint='max_norm',
-                                     input_shape=(10, 16)))
+                                     input_shape=(16, 10)))
         model.build()
         json_string = Model.to_json(model)
         with open(os.path.join(settings.BASE_DIR, 'media', 'test.json'), 'w') as out:
@@ -584,7 +601,7 @@ class GaussianNoiseImportTest(unittest.TestCase, HelperFunctions):
 
     def test_keras_import(self):
         model = Sequential()
-        model.add(GaussianNoise(stddev=0.1, input_shape=(1, 16)))
+        model.add(GaussianNoise(stddev=0.1, input_shape=(16, 1)))
         model.build()
         self.keras_param_test(model, 0, 1)
 
@@ -595,7 +612,7 @@ class GaussianDropoutImportTest(unittest.TestCase, HelperFunctions):
 
     def test_keras_import(self):
         model = Sequential()
-        model.add(GaussianDropout(rate=0.5, input_shape=(1, 16)))
+        model.add(GaussianDropout(rate=0.5, input_shape=(16, 1)))
         model.build()
         self.keras_param_test(model, 0, 1)
 
@@ -606,7 +623,7 @@ class AlphaDropoutImportTest(unittest.TestCase, HelperFunctions):
 
     def test_keras_import(self):
         model = Sequential()
-        model.add(AlphaDropout(rate=0.5, seed=5, input_shape=(1, 16)))
+        model.add(AlphaDropout(rate=0.5, seed=5, input_shape=(16, 1)))
         model.build()
         self.keras_param_test(model, 0, 1)
 


### PR DESCRIPTION
**Update:**

- Added an extra dependency for TensorFlow installation, and exported a variable to fix the build error.

**Change Log:** (Only the TF Backend part of #309)

- Fixed a failing unittest while using TensorFlow backend for Keras.
- Added code to reset graph before importing, in tensorflow_app/views/**import_graphdef.py**
- Added unittest for testing dimension ordering (channels last/first) . By default, in our case, the channels last ordering is used for both Theano and TensorFlow. The unittest is used to verify the same.
- Modified all import unittests, and a line in import_graphdef.py, to use channels last ordering, as it should be. The export tests only tests if the layer's name is correct, so it was left intact.
- Modified README to change server deploying instruction to use the default backend (TensorFlow). 
- Modified travis.yml to run tests with keras backend as TensorFlow

@utsavgarg please review.