### PR TITLE
Keras Separable Conv2D with TF Backend

### DIFF
--- a/ide/static/js/content.js
+++ b/ide/static/js/content.js
@@ -282,7 +282,7 @@ class Content extends React.Component {
     var weight_params = 0;
     var bias_params = 0;
 
-    var filter_layers = ["Convolution", "Deconvolution"];
+    var filter_layers = ["Convolution", "Deconvolution", "DepthwiseConv"];
     var fc_layers = ["InnerProduct", "Embed", "Recurrent", "LSTM"];
 
     if(filter_layers.includes(layer.info.type)) {
@@ -463,6 +463,8 @@ class Content extends React.Component {
     }
     data['Convolution']['params']['weight_filler']['options'] = fillers;
     data['Convolution']['params']['bias_filler']['options'] = fillers;
+    data['DepthwiseConv']['params']['weight_filler']['options'] = fillers;
+    data['DepthwiseConv']['params']['bias_filler']['options'] = fillers;
     data['Deconvolution']['params']['weight_filler']['options'] = fillers;
     data['Deconvolution']['params']['bias_filler']['options'] = fillers;
     data['Recurrent']['params']['weight_filler']['options'] = fillers;
@@ -531,7 +533,8 @@ class Content extends React.Component {
             layer.params[param] = [layer.params[param], false];
           }
         });
-        if (type == 'Convolution' || type == 'Pooling' || type == 'Upsample' || type == 'LocallyConnected' || type == 'Eltwise'){
+        if (type == 'Convolution' || type == 'Pooling' || type == 'Upsample' || type == 'LocallyConnected' ||
+            type == 'Eltwise' || type == 'DepthwiseConv'){
           layer = this.adjustParameters(layer, 'layer_type', layer.params['layer_type'][0]);
         }
         // layer.props = JSON.parse(JSON.stringify(data[type].props));
@@ -710,6 +713,15 @@ class Content extends React.Component {
         if (value == 'Average' || value == 'Dot'){
           layer.params['caffe'] = [false, false];
         }
+      }
+      else if (layer.info['type'] == 'DepthwiseConv'){
+        layer.params['caffe'] = [false, false];
+        layer.params['kernel_h'] = [layer.params['kernel_h'][0], false];
+        layer.params['kernel_d'] = [layer.params['kernel_d'][0], true];
+        layer.params['pad_h'] = [layer.params['pad_h'][0], false];
+        layer.params['pad_d'] = [layer.params['pad_d'][0], true];
+        layer.params['stride_h'] = [layer.params['stride_h'][0], false];
+        layer.params['stride_d'] = [layer.params['stride_d'][0], true];
       }
     }
     return layer;

--- a/ide/static/js/pane.js
+++ b/ide/static/js/pane.js
@@ -104,6 +104,9 @@ class Pane extends React.Component {
                     <PaneElement setDraggingLayer={this.props.setDraggingLayer}
                       handleClick={this.props.handleClick}
                       id="Deconvolution">Deconvolution</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="DepthwiseConv">Depthwise Convolution</PaneElement>
                   </div>
                 </div>
               </div>

--- a/ide/utils/shapes.py
+++ b/ide/utils/shapes.py
@@ -26,7 +26,7 @@ def filter(layer):
         num_out = layer['shape']['input'][0]
     else:
         num_out = layer['params']['num_output']
-    if (layer['info']['type'] in ['Deconvolution', 'DepthwiseConv']):
+    if (layer['info']['type'] == 'Deconvolution'):
         _, i_h, i_w = layer['shape']['input']
         k_h, k_w = layer['params']['kernel_h'], layer['params']['kernel_w']
         s_h, s_w = layer['params']['stride_h'], layer['params']['stride_w']
@@ -42,7 +42,7 @@ def filter(layer):
             p_w = layer['params']['pad_w']
             o_w = int((i_w + 2 * p_w - k_w) / float(s_w) + 1)
             return [num_out, o_w]
-        elif (layer['params']['layer_type'] == '2D'):
+        elif (layer['params']['layer_type'] == '2D' or layer['info']['type'] == 'DepthwiseConv'):
             _, i_h, i_w = layer['shape']['input']
             k_h, k_w = layer['params']['kernel_h'], layer['params']['kernel_w']
             s_h, s_w = layer['params']['stride_h'], layer['params']['stride_w']

--- a/keras_app/views/export_json.py
+++ b/keras_app/views/export_json.py
@@ -10,7 +10,7 @@ from keras.models import Model
 from layers_export import data, convolution, deconvolution, pooling, dense, dropout, embed,\
     recurrent, batch_norm, activation, flatten, reshape, eltwise, concat, upsample, locally_connected,\
     permute, repeat_vector, regularization, masking, gaussian_noise, gaussian_dropout, alpha_dropout, \
-    bidirectional, time_distributed
+    bidirectional, time_distributed, depthwise_conv
 BASE_DIR = os.path.dirname(
     os.path.dirname(
         os.path.dirname(
@@ -72,7 +72,8 @@ def export_json(request, is_tf=False):
             'AlphaDropout': alpha_dropout,
             'Scale': '',
             'TimeDistributed': time_distributed,
-            'Bidirectional': bidirectional
+            'Bidirectional': bidirectional,
+            'DepthwiseConv': depthwise_conv
         }
 
         # Remove any duplicate activation layers (timedistributed and bidirectional layers)

--- a/keras_app/views/import_json.py
+++ b/keras_app/views/import_json.py
@@ -10,7 +10,7 @@ from layers_import import Input, Convolution, Deconvolution, Pooling, Dense, Dro
     Recurrent, BatchNorm, Activation, LeakyReLU, PReLU, ELU, Scale, Flatten, Reshape, Concat, \
     Eltwise, Padding, Upsample, LocallyConnected, ThresholdedReLU, Permute, RepeatVector,\
     ActivityRegularization, Masking, GaussianNoise, GaussianDropout, AlphaDropout, \
-    TimeDistributed, Bidirectional
+    TimeDistributed, Bidirectional, DepthwiseConv
 from keras.models import model_from_json, Sequential
 from keras.layers import deserialize
 
@@ -72,6 +72,7 @@ def import_json(request):
         'Conv2D': Convolution,
         'Conv2DTranspose': Deconvolution,
         'Conv3D': Convolution,
+        'SeparableConv2D': DepthwiseConv,
         'UpSampling1D': Upsample,
         'UpSampling2D': Upsample,
         'UpSampling3D': Upsample,

--- a/keras_app/views/layers_export.py
+++ b/keras_app/views/layers_export.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from keras.layers import Dense, Activation, Dropout, Flatten, Reshape, Permute, RepeatVector
 from keras.layers import ActivityRegularization, Masking
+from keras.layers import SeparableConv2D
 from keras.layers import Conv1D, Conv2D, Conv3D, Conv2DTranspose
 from keras.layers import UpSampling1D, UpSampling2D, UpSampling3D
 from keras.layers import MaxPooling1D, MaxPooling2D, MaxPooling3D
@@ -241,9 +242,7 @@ def convolution(layer, layer_in, layerId, tensor=True):
     return out
 
 
-# Separable Convolution is currently not supported with Theano backend
-'''
-def depthwiseConv(layer, layer_in, layerId, tensor=True):
+def depthwise_conv(layer, layer_in, layerId, tensor=True):
     out = {}
     padding = get_padding(layer)
     filters = layer['params']['filters']
@@ -278,7 +277,7 @@ def depthwiseConv(layer, layer_in, layerId, tensor=True):
                                    depthwise_constraint=depthwise_constraint,
                                    pointwise_constraint=pointwise_constraint,
                                    bias_constraint=bias_constraint,)(*layer_in)
-    return out'''
+    return out
 
 
 def deconvolution(layer, layer_in, layerId, tensor=True):

--- a/keras_app/views/layers_import.py
+++ b/keras_app/views/layers_import.py
@@ -151,8 +151,6 @@ def Convolution(layer):
     return jsonLayer('Convolution', params, layer)
 
 
-# Separable Convolution is currently not supported with Theano backend
-'''
 def DepthwiseConv(layer):
     params = {}
     params['filters'] = layer.filters
@@ -181,7 +179,7 @@ def DepthwiseConv(layer):
         params['pointwise_constraint'] = layer.pointwise_constraint.__class__.__name__
     if (layer.bias_constraint):
         params['bias_constraint'] = layer.bias_constraint.__class__.__name__
-    return jsonLayer('DepthwiseConv', params, layer)'''
+    return jsonLayer('DepthwiseConv', params, layer)
 
 
 def Deconvolution(layer):

--- a/tests/unit/keras_app/keras_export_test.json
+++ b/tests/unit/keras_app/keras_export_test.json
@@ -96,7 +96,52 @@
                 224
             ]
         }
-    }, 
+    },
+    "DepthwiseConv": {
+        "connection": {
+            "input": [
+                "l0"
+            ], 
+            "output": []
+        }, 
+        "info": {
+            "phase": null, 
+            "type": "DepthwiseConv"
+        },
+        "params": {
+            "filters": 32,
+            "kernel_h": 3,
+            "kernel_w": 3,
+            "stride_h": 1,
+            "stride_w": 1,
+            "pad_h": 0,
+            "pad_w": 0,
+            "depth_multiplier": 1,
+            "use_bias": true,
+            "depthwise_initializer": "VarianceScaling",
+            "pointwise_initializer": "VarianceScaling",
+            "bias_initializer": "VarianceScaling",
+            "depthwise_regularizer": "L1L2",
+            "pointwise_regularizer": "L1L2",
+            "bias_regularizer": "L1L2",
+            "activity_regularizer": "L1L2",
+            "depthwise_constraint": "MaxNorm",
+            "pointwise_constraint": "MaxNorm",
+            "bias_constraint": "MaxNorm"
+        },
+        "shape": {
+            "input": [
+                3, 
+                224, 
+                224
+            ], 
+            "output": [
+                128, 
+                230, 
+                230
+            ]
+        }    
+    },    
     "Deconvolution": {
         "connection": {
             "input": [


### PR DESCRIPTION
**Change Log:** (The 2nd part of #309)

- Separable Conv2D was only compatible with TF backend and not Theano. Since master is in sync with TF backend, I'm introducing functionality for SeparableConv2D.
- Wrote the missing export unittest for the same. The import and export unittests are skipped if backend used is theano. 
