### PR TITLE
Updated the docker-compose up --build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Setting up Fabrik on your local machine is really easy. You can setup Fabrik usi
 3. Build and run the Docker containers. This might take a while. You should be able to access Fabrik at `0.0.0.0:8000`.
 
     ```
-    docker-compose up --build
+    sudo docker-compose up --build
     ```
 
 ### Using Virtual Environment


### PR DESCRIPTION
docker-compose up --build command always gives the "Error: Couldn't connect to Docker Daemon". Using sudo docker-compose up --build fixes the error. 
This will help new contributors set up the repository correctly the first time itself.