### PR TITLE
Fix broken markdown link in tested_models.md

### DIFF
--- a/docs/source/tested_models.md
+++ b/docs/source/tested_models.md
@@ -46,7 +46,7 @@
 
 ## Segmentation
 * Image Segmentation CRF-RNN [\[Source\]](https://github.com/torrvision/crfasrnn/tree/master/python-scripts)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20180111183110okaux)
-* UNET [\[Source\]](https://github.com/ZFTurbo/ZF_UNET_224_Pretrained_Model)[\[Visualise]](http://fabrik.cloudcv.org/caffe/load?id=20180116070834rggzh)
+* UNET [\[Source\]](https://github.com/ZFTurbo/ZF_UNET_224_Pretrained_Model)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20180116070834rggzh)
 
 ### Miscellaneous
 

--- a/tutorials/tested_models.md
+++ b/tutorials/tested_models.md
@@ -49,7 +49,7 @@
 
 ## Segmentation
 * Image Segmentation CRF-RNN [\[Source\]](https://github.com/torrvision/crfasrnn/tree/master/python-scripts)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20180111183110okaux)
-* UNET [\[Source\]](https://github.com/ZFTurbo/ZF_UNET_224_Pretrained_Model)[\[Visualise]](http://fabrik.cloudcv.org/caffe/load?id=20180116070834rggzh)
+* UNET [\[Source\]](https://github.com/ZFTurbo/ZF_UNET_224_Pretrained_Model)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20180116070834rggzh)
 
 ### Miscellaneous
 


### PR DESCRIPTION
Just saw this and thought I'd fix it.
![image](https://user-images.githubusercontent.com/16677912/47840033-0b45dd00-de09-11e8-86bc-54e2f40b043e.png)