### PR TITLE
Added Slice layer to pane.js

### DIFF
--- a/ide/static/js/pane.js
+++ b/ide/static/js/pane.js
@@ -250,6 +250,9 @@ class Pane extends React.Component {
                     <PaneElement setDraggingLayer={this.props.setDraggingLayer}
                       handleClick={this.props.handleClick}
                       id="Masking_Button">Masking</PaneElement>
+                    <PaneElement setDraggingLayer={this.props.setDraggingLayer}
+                      handleClick={this.props.handleClick}
+                      id="Slice_Button">Slice</PaneElement>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
As noted in #418, Slice layer was not added to `pane.js` despite having been defined in `data.js` and the `caffe_app` files. This PR adds the layer to `pane.js`