### PR TITLE
Updated Tensorflow version

### DIFF
--- a/requirements/caffe_tensorflow_keras_install.sh
+++ b/requirements/caffe_tensorflow_keras_install.sh
@@ -37,7 +37,7 @@ sudo apt-get -y install python-pip python-dev google-perftools libgoogle-glog-de
 export LD_PRELOAD="/usr/lib/libtcmalloc.so.4"
 
 echo "Installing Tensorflow"
-pip install tensorflow==1.10.1
+pip install tensorflow==1.12.0
 
 echo "#################### Tensorflow Install Complete! ####################"
 

--- a/requirements/caffe_tensorflow_keras_install.sh
+++ b/requirements/caffe_tensorflow_keras_install.sh
@@ -37,7 +37,7 @@ sudo apt-get -y install python-pip python-dev google-perftools libgoogle-glog-de
 export LD_PRELOAD="/usr/lib/libtcmalloc.so.4"
 
 echo "Installing Tensorflow"
-pip install tensorflow==1.4.1
+pip install tensorflow==1.10.1
 
 echo "#################### Tensorflow Install Complete! ####################"
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -5,7 +5,7 @@ asgi-redis==1.2.1
 pyaml==15.8.2
 django-allauth==0.30.0
 psycopg2==2.7.3
-tensorflow==1.10.1
+tensorflow==1.12.0
 theano==0.9.0
 keras==2.0.8
 uWSGI==2.0.17

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -5,7 +5,7 @@ asgi-redis==1.2.1
 pyaml==15.8.2
 django-allauth==0.30.0
 psycopg2==2.7.3
-tensorflow==1.4.1
+tensorflow==1.10.1
 theano==0.9.0
 keras==2.0.8
 uWSGI==2.0.17


### PR DESCRIPTION
GCI [Task](https://codein.withgoogle.com/dashboard/task-instances/6595974689456128/): Updated Tensorflow version from version 1.4.1 => 1.12.0

Tensorflow 1.9.0 did not work as an _ImportError: dlopen: cannot load any more object with static TLS_ was thrown.
Travis CI build for Tenserflow 1.9.0 [here](https://travis-ci.com/c0derlint/Fabrik/builds/90459224).