### PR TITLE
Edits of index.html to protect against XSS and MIME attacks

### DIFF
--- a/ide/templates/index.html
+++ b/ide/templates/index.html
@@ -20,6 +20,7 @@
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
     gtag('config', 'UA-110495971-1');
+    XMLHttpRequest.setRequestHeader(X-Content-Type-Options, nosniff)
   </script>
 
 </head>

--- a/ide/templates/index.html
+++ b/ide/templates/index.html
@@ -20,7 +20,8 @@
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
     gtag('config', 'UA-110495971-1');
-    XMLHttpRequest.setRequestHeader(X-Content-Type-Options, nosniff)
+    response.setHeader('X-Content-Type-Options', 'nosniff')
+    response.setHeader('X-XSS-Protection', '1; mode=block')
   </script>
 
 </head>


### PR DESCRIPTION
Fixed "Web Browser XSS Protection Not Enabled" and "X-Content-Type-Options Header Missing"
The HTTP library (Node) was used to resolve this issue. I used the response function to set the HTTP header.