### PR TITLE
Fix #484: Fixed misalignment issue under 'Wrapper' section

### DIFF
--- a/ide/static/css/zoo.css
+++ b/ide/static/css/zoo.css
@@ -2,7 +2,7 @@ body {
     overflow-x: hidden;
  }
 
-#wrapper {
+#content-wrapper {
     padding-left: 250px;
 }
 

--- a/ide/static/js/modelZoo.js
+++ b/ide/static/js/modelZoo.js
@@ -98,7 +98,7 @@ class ModelZoo extends React.Component {
 
     return (
       <div className="sidebar-content">
-        <div id="wrapper" className="toggle" ref="wrapper1">
+        <div id="content-wrapper" className="toggle" ref="wrapper1">
           <div id="sidebar-wrapper">
             <ul id="sidebar-nav" className="sidebar-nav">
                 <div className="filterbar-container">


### PR DESCRIPTION
Fixed the issue of items under the 'Wrapper' section being misaligned (issue #484).


![screenshot from 2018-12-19 15-35-51](https://user-images.githubusercontent.com/28645536/50213657-404fc400-03a4-11e9-8179-c0467e7f4fea.png)


