### PR TITLE
Fix #524, fix few broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Fabrik is an online collaborative platform to build, visualize and train deep le
 
 <img src="/example/fabrik_demo.gif?raw=true">
 
-This app is presently under active development and we welcome contributions. Please check out our [issues thread](https://github.com/Cloud-CV/IDE/issues) to find things to work on, or ping us on [Gitter](https://gitter.im/Cloud-CV/IDE).
+This app is presently under active development and we welcome contributions. Please check out our [issues thread](https://github.com/Cloud-CV/Fabrik/issues) to find things to work on, or ping us on [Gitter](https://gitter.im/Cloud-CV/Fabrik).
 
 
 ## Installation Instructions
@@ -103,7 +103,7 @@ To install Docker for Mac [click here](https://docs.docker.com/docker-for-mac/in
     * Change the hostname to ``` localhost ``` in settings/dev.py line 15. It should now look like this:  
 
     ```
-    'HOST': os.environ.get("POSTGRES_HOST", 'localhost'), 
+    'HOST': os.environ.get("POSTGRES_HOST", 'localhost'),
     ```
 
 4. Install redis server  
@@ -158,7 +158,7 @@ To install Docker for Mac [click here](https://docs.docker.com/docker-for-mac/in
 
 * For Mac users
     * [Install Caffe](http://caffe.berkeleyvision.org/install_osx.html)
-    * [Install Tensorflow](https://www.tensorflow.org/install/install_mac)
+    * [Install Tensorflow](https://www.tensorflow.org/install)
     * [Install Keras](https://keras.io/#installation)
 
 6. Install dependencies
@@ -205,7 +205,7 @@ To install Docker for Mac [click here](https://docs.docker.com/docker-for-mac/in
     sudo npm install -g webpack@1.15.0
     ```
 
-    * Run the command below in a separate terminal for hot-reloading, i.e. see the changes made to the UI in real time. 
+    * Run the command below in a separate terminal for hot-reloading, i.e. see the changes made to the UI in real time.
 
     ```
     webpack --progress --watch --colors
@@ -260,7 +260,7 @@ To install Docker for Mac [click here](https://docs.docker.com/docker-for-mac/in
 
     * Choose  the ``` Provider ``` of social application as ``` Github ``` &  name it ``` Github ```.
 
-    * Add the sites available to the right side, so github is allowed for the current site. This should be `localhost:8000` for local deployment.
+    * Add the sites available to the right side, so Github is allowed for the current site. This should be `localhost:8000` for local deployment.
 
     * Copy and paste your ``` Client ID ``` and ``` Secret Key ``` into the appropriate fields and Save.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <img width="25%" src="/ide/static/img/logo.png" />
 
+
 [![Join the chat at https://gitter.im/Cloud-CV/Fabrik](https://badges.gitter.im/Cloud-CV/Fabrik.svg)](https://gitter.im/Cloud-CV/Fabrik?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/Cloud-CV/Fabrik.svg?branch=master)](https://travis-ci.org/Cloud-CV/Fabrik)
 [![Coverage Status](https://coveralls.io/repos/github/Cloud-CV/Fabrik/badge.svg?branch=master)](https://coveralls.io/github/Cloud-CV/Fabrik?branch=master)

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ To install Docker for Mac [click here](https://docs.docker.com/docker-for-mac/in
 
 * For Mac users
     * [Install Caffe](http://caffe.berkeleyvision.org/install_osx.html)
-    * [Install Tensorflow](https://www.tensorflow.org/install)
+    * [Install Tensorflow](https://github.com/tensorflow/docs/blob/r1.4/site/en/install/install_mac.md#installing-with-virtualenv)
     * [Install Keras](https://keras.io/#installation)
 
 6. Install dependencies

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <img width="25%" src="/ide/static/img/logo.png" />
 
-
 [![Join the chat at https://gitter.im/Cloud-CV/Fabrik](https://badges.gitter.im/Cloud-CV/Fabrik.svg)](https://gitter.im/Cloud-CV/Fabrik?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/Cloud-CV/Fabrik.svg?branch=master)](https://travis-ci.org/Cloud-CV/Fabrik)
 [![Coverage Status](https://coveralls.io/repos/github/Cloud-CV/Fabrik/badge.svg?branch=master)](https://coveralls.io/github/Cloud-CV/Fabrik?branch=master)

--- a/docs/source/setup.md
+++ b/docs/source/setup.md
@@ -1,16 +1,16 @@
 ## How to setup
 1. First set up a virtualenv
     ```
-    sudo apt-get install python-pip python-dev python-virtualenv 
+    sudo apt-get install python-pip python-dev python-virtualenv
     virtualenv --system-site-packages ~/Fabrik
     source ~/Fabrik/bin/activate
     ```
-    
+
 2. Clone the repository
     ```
     git clone --recursive https://github.com/Cloud-CV/Fabrik.git
     ```
-    
+
 3. If you have Caffe, Keras and Tensorflow already installed on your computer, skip this step
     * For Linux users
         ```
@@ -24,11 +24,11 @@
         Save, exit and then run
         ```
         source ~/.bash_profile
-        cd .. 
+        cd ..
         ```
     * For Mac users
         * [Install Caffe](http://caffe.berkeleyvision.org/install_osx.html)
-        * [Install Tensorflow](https://www.tensorflow.org/versions/r0.12/get_started/os_setup#virtualenv_installation)
+        * [Install Tensorflow](https://github.com/tensorflow/docs/blob/r1.4/site/en/install/install_mac.md#installing-with-virtualenv)
         * [Install Keras](https://keras.io/#installation)
 4. Install dependencies
 * For developers:
@@ -43,7 +43,7 @@
 * Setup postgres database
     * Start postgresql by typing ```sudo service postgresql start```
     * Now login as user postgres by running ```sudo -u postgres psql``` and type the commands below
-    
+
     ```
       CREATE DATABASE fabrik;
       CREATE USER admin WITH PASSWORD 'fabrik';
@@ -52,10 +52,10 @@
       ALTER ROLE admin SET timezone TO 'UTC';
       ALTER USER admin CREATEDB;
     ```
-    * Exit psql by typing in \q and hitting enter. 
+    * Exit psql by typing in \q and hitting enter.
 * Migrate
     ```
-    
+
     python manage.py makemigrations caffe_app
     python manage.py migrate
     ```

--- a/docs/source/tested_models.md
+++ b/docs/source/tested_models.md
@@ -33,7 +33,7 @@
 
 ### Seq2Seq
 
-* Seq2Seq Translation [\[Source\]](https://github.com/fchollet/keras/blob/master/examples/lstm_seq2seq.py)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208115116hsfax)
+* Seq2Seq Translation [\[Source\]](https://github.com/keras-team/keras/blob/master/examples/lstm_seq2seq.py)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208115116hsfax)
 * Text Generation [\[Source\]](https://machinelearningmastery.com/text-generation-lstm-recurrent-neural-networks-python-keras/)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208113517iphlh)
 * Pix2Pix [\[Source\]](https://github.com/phillipi/pix2pix) [\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20180105143836eahgb)
 * Denoising Auto-Encoder [\[Source\]](https://blog.keras.io/building-autoencoders-in-keras.html)

--- a/tutorials/tested_models.md
+++ b/tutorials/tested_models.md
@@ -38,7 +38,7 @@
 
 ### Seq2Seq
 
-* Seq2Seq Translation [\[Source\]](https://github.com/fchollet/keras/blob/master/examples/lstm_seq2seq.py)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208115116hsfax)
+* Seq2Seq Translation [\[Source\]](https://github.com/keras-team/keras/blob/master/examples/lstm_seq2seq.py)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208115116hsfax)
 * Text Generation [\[Source\]](https://machinelearningmastery.com/text-generation-lstm-recurrent-neural-networks-python-keras/)[\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20171208113517iphlh)
 * Pix2Pix [\[Source\]](https://github.com/phillipi/pix2pix) [\[Visualise\]](http://fabrik.cloudcv.org/caffe/load?id=20180105143836eahgb)
 


### PR DESCRIPTION
First fix for https://github.com/Cloud-CV/Fabrik/issues/524
CL:
* Changed IDE to Fabrik in README.md
* Updated broken link for installing TensorFlow for mac from https://www.tensorflow.org/versions/r0.12/get_started/os_setup#virtualenv_installation to https://github.com/tensorflow/docs/blob/r1.4/site/en/install/install_mac.md#installing-with-virtualenv
* Updated Seq2Seq source in tested_models.md to point to the Keras official repository.
